### PR TITLE
Potential fix for code scanning alert no. 15: Incomplete string escaping or encoding

### DIFF
--- a/plugins/AdminLTE/view/js/datatables/jquery.dataTables.js
+++ b/plugins/AdminLTE/view/js/datatables/jquery.dataTables.js
@@ -3026,7 +3026,7 @@
 					word = m ? m[1] : word;
 				}
 	
-				return word.replace('"', '');
+				return word.replace(/"/g, '');
 			} );
 	
 			search = '^(?=.*?'+a.join( ')(?=.*?' )+').*$';


### PR DESCRIPTION
Potential fix for [https://github.com/eltictacdicta/fs-framework/security/code-scanning/15](https://github.com/eltictacdicta/fs-framework/security/code-scanning/15)

To fix the problem, `word.replace('"', '')` should be changed so that it removes all occurrences of the double quote character, not just the first one. The usual way to do this in JavaScript is to use a regular expression with the global (`g`) flag, e.g. `word.replace(/"/g, '')`. This ensures every `"` in the string is removed, aligning with the “strip quotes” intent and avoiding partial escaping.

Concretely, in `plugins/AdminLTE/view/js/datatables/jquery.dataTables.js`, inside the `_fnFilterCreateSearch` function’s `$.map` callback (around line 3029), change the single-argument string `.replace('"', '')` to use a global regular expression: `.replace(/"/g, '')`. No additional imports or helper methods are needed; this uses standard JavaScript functionality and does not change any other behavior of the function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes quote stripping in DataTables search tokenization to remove all `"` characters rather than only the first, improving correctness of the constructed regex for multi-term searches.
> 
> - In `plugins/AdminLTE/view/js/datatables/jquery.dataTables.js` (`_fnFilterCreateSearch`), change `word.replace('"', '')` to `word.replace(/"/g, '')` within the `$.map` callback
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c14812e7ee7affcdac21cd5e76629679bdfa840. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->